### PR TITLE
Use window._filloutEmbedUrl for environment-aware embed URL

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,16 +1,10 @@
 import { useState, useEffect } from "react";
 
-const getDefaultBaseUrl = () => {
-  try {
-    // Allow overriding via Vite env for staging/local dev
-    // @ts-ignore - import.meta.env is injected by Vite at build time
-    const envUrl = import.meta.env?.VITE_FILLOUT_EMBED_URL;
-    if (envUrl) return envUrl;
-  } catch {}
-  return "https://embed.fillout.com";
-};
+const DEFAULT_BASE_URL = "https://embed.fillout.com";
 
-const FILLOUT_BASE_URL = getDefaultBaseUrl();
+const getBaseUrl = (): string =>
+  (typeof window !== "undefined" && (window as Record<string, unknown>)._filloutEmbedUrl as string) ||
+  DEFAULT_BASE_URL;
 
 const generateEmbedId = () => {
   const min = 10000000000000;
@@ -56,7 +50,7 @@ export const useFilloutEmbed = ({
       : isLocalhost
       ? `http://${domain}`
       : `https://${domain}`
-    : FILLOUT_BASE_URL;
+    : getBaseUrl();
   const iframeUrl = new URL(`${origin}/t/${encodeURIComponent(filloutId)}`);
 
   // inherit query params


### PR DESCRIPTION
## Summary
- The `import.meta.env` approach from #9 didn't work — tsup compiles `import.meta` to an empty object, so the env var was never read
- Instead, read from `window._filloutEmbedUrl` which is set by app-runtime before the app loads
- Keeps the localhost `domain` prop fix from #9

## How it works
- App-runtime sets `window._filloutEmbedUrl` based on the environment (staging/local dev)
- `@fillout/react` reads it at render time as the default embed URL
- Prod doesn't set the global, so the default `embed.fillout.com` is used

## Test plan
- [ ] Local dev: app-runtime sets `window._filloutEmbedUrl = 'http://localhost:3000'`, embeds load from localhost
- [ ] Staging: app-runtime sets `window._filloutEmbedUrl = 'https://form.filloutstaging.com'`, embeds load from staging
- [ ] Prod: global not set, embeds load from `embed.fillout.com` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated embed configuration mechanism to support runtime browser-based URL overrides, replacing environment variable-based setup while maintaining backward compatibility with default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->